### PR TITLE
Export: Fix Errors And Add Documentation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -21,7 +21,7 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Exports persons identified by the index numbers used in the last person listing to a save file.\n"
         + "Parameters: INDEX; FILEPATH (Indexes must be positive integers separated by commas or spaces)\n"
-        + "Example: " + COMMAND_WORD + " 1, 2 3; \"/Users/[User Name]/Desktop/persons.xml\"";
+        + "Example: " + COMMAND_WORD + " 1, 2 3; /Users/[User Name]/Desktop/persons.xml";
 
     public static final String MESSAGE_EXPORT_PERSON_SUCCESS = "Your contacts: %1$shave been exported to file: %2$s";
 

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -46,6 +46,24 @@ public class ExportCommandParser implements Parser<ExportCommand> {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MISSING_FILE_PATH + ExportCommand.MESSAGE_USAGE));
         }
 
-        return new ExportCommand(indexes, filePath);
+        return new ExportCommand(indexes, addXmlExtensionToFilePath(filePath));
+    }
+
+    /**
+     *  Add ".xml" extension if input filePath do not have one.
+     */
+    private String addXmlExtensionToFilePath(String filePath) {
+
+        if (!filePath.contains(".")) {
+            return filePath + ".xml";
+        }
+        String extension = "";
+        if (filePath.charAt(filePath.lastIndexOf('.') - 1) != '/') {
+            extension = filePath.substring(filePath.lastIndexOf('.') + 1, filePath.length());
+        }
+        if (!extension.equalsIgnoreCase("xml")) {
+            return filePath + ".xml";
+        }
+        return filePath;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -35,7 +35,7 @@ public class ExportCommandParser implements Parser<ExportCommand> {
         // parse indexes
         List<Index> indexes;
         try {
-            indexes = ParserUtil.parserIndexList(oneBasedIndexListString);
+            indexes = ParserUtil.parseIndexList(oneBasedIndexListString);
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -58,7 +58,8 @@ public class ExportCommandParser implements Parser<ExportCommand> {
             return filePath + ".xml";
         }
         String extension = "";
-        if (filePath.charAt(filePath.lastIndexOf('.') - 1) != '/') {
+        if (filePath.charAt(filePath.lastIndexOf('.') - 1) != '/'
+            && filePath.charAt(filePath.lastIndexOf('.') - 1) != '\\') {
             extension = filePath.substring(filePath.lastIndexOf('.') + 1, filePath.length());
         }
         if (!extension.equalsIgnoreCase("xml")) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -51,7 +51,7 @@ public class ParserUtil {
      * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static List<Index> parseIndexList(String oneBasedIndexList) throws IllegalValueException {
-        String[] indexStrings = oneBasedIndexList.split("(,)*(\\s)*");
+        String[] indexStrings = oneBasedIndexList.split("((,)|(\\s))+");
         List<Index> indexes = new ArrayList<>();
         for (String s : indexStrings) {
             if (!s.trim().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -50,7 +50,7 @@ public class ParserUtil {
      * The numbers must be separated by whitespaces or ",".
      * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
      */
-    public static List<Index> parserIndexList(String oneBasedIndexList) throws IllegalValueException {
+    public static List<Index> parseIndexList(String oneBasedIndexList) throws IllegalValueException {
         String[] indexStrings = oneBasedIndexList.split("(,)*(\\s)*");
         List<Index> indexes = new ArrayList<>();
         for (String s : indexStrings) {

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -23,25 +23,25 @@ public class ExportCommandParserTest {
     private ExportCommandParser parser = new ExportCommandParser();
 
     @Test
-    public void parser_missingSemicolon_failure() {
+    public void parse_missingSemicolon_failure() {
         String input = "1 " + VALID_FILE_PATH;
         assertParseFailure(parser, input, EXPECTED_MATCH_ERROR_MESSAGE);
     }
 
     @Test
-    public void parser_missingIndex_failure() {
+    public void parse_missingIndex_failure() {
         String input = " ; " + VALID_FILE_PATH;
         assertParseFailure(parser, input, EXPECTED_MATCH_ERROR_MESSAGE);
     }
 
     @Test
-    public void parser_missingFilePath_failure() {
+    public void parse_missingFilePath_failure() {
         String input = "1 ; ";
         assertParseFailure(parser, input, EXPECTED_FILE_MISSING_ERROR_MESSAGE);
     }
 
     @Test
-    public void parser_invalidIndex_failure() {
+    public void parse_invalidIndex_failure() {
         String input = "1, 2 3-4 ; " + VALID_FILE_PATH;
         assertParseFailure(parser, input, EXPECTED_MATCH_ERROR_MESSAGE);
 
@@ -72,7 +72,7 @@ public class ExportCommandParserTest {
     }
 
     @Test
-    public void parser_validArgs_success() {
+    public void parse_validArgs_success() {
         List<Index> indexes = getIndexListFromOneBasedArray(1, 2, 3);
         String input = "1, 2 3 ; " + VALID_FILE_PATH;
         ExportCommand exportCommand = new ExportCommand(indexes, VALID_FILE_PATH.trim());

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -50,6 +50,28 @@ public class ExportCommandParserTest {
     }
 
     @Test
+    public void parse_filePathWithInvalidExtension_successWithModifiedFilePath() {
+        String xmlExtension = ".xml";
+        String validIndexList = "1, 2;";
+        List<Index> validIndexes = getIndexListFromOneBasedArray(1, 2);
+
+        // no extension -> add .xml to filePath
+        String filePathWithoutExtension = "TestFile";
+        assertParseSuccess(parser, validIndexList + filePathWithoutExtension,
+            new ExportCommand(validIndexes, filePathWithoutExtension + xmlExtension));
+
+        // wrong extension -> add .xml to filePath
+        String filePathWithWrongExtension = "TestFile.txt";
+        assertParseSuccess(parser, validIndexList + filePathWithWrongExtension,
+            new ExportCommand(validIndexes, filePathWithWrongExtension + xmlExtension));
+
+        // */.xml -> add .xml to filePath
+        String filePathWithoutFileName = "./.xml";
+        assertParseSuccess(parser, validIndexList + filePathWithoutFileName,
+            new ExportCommand(validIndexes, filePathWithoutFileName + xmlExtension));
+    }
+
+    @Test
     public void parser_validArgs_success() {
         List<Index> indexes = getIndexListFromOneBasedArray(1, 2, 3);
         String input = "1, 2 3 ; " + VALID_FILE_PATH;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.logic.parser.ParserUtil.parserIndexList;
+import static seedu.address.logic.parser.ParserUtil.parseIndexList;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_LIST_FIRST_TO_THIRD;
 
@@ -66,15 +66,15 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parserIndexList_validInput_success() throws Exception {
+    public void parseIndexList_validInput_success() throws Exception {
         // separated by whitespaces
-        assertEquals(INDEX_LIST_FIRST_TO_THIRD, ParserUtil.parserIndexList("1 2 3"));
+        assertEquals(INDEX_LIST_FIRST_TO_THIRD, ParserUtil.parseIndexList("1 2 3"));
 
         // separated by ","
-        assertEquals(INDEX_LIST_FIRST_TO_THIRD, parserIndexList("1, 2, 3"));
+        assertEquals(INDEX_LIST_FIRST_TO_THIRD, parseIndexList("1, 2, 3"));
 
         // Leading and trailing whitespaces and ","s
-        assertEquals(INDEX_LIST_FIRST_TO_THIRD, parserIndexList("  ,, ,1, 2 3  ,,"));
+        assertEquals(INDEX_LIST_FIRST_TO_THIRD, parseIndexList("  ,, ,1, 2 3  ,,"));
     }
 
     @Test


### PR DESCRIPTION
## Export Command Error Fix

1. The example of export command was 
    _export 1, 2 3; "/Users/[User Name]/Desktop/onePerson.xml"_. 
Change it to
    _export 1, 2 3; /Users/[User Name]/Desktop/onePerson.xml_
to match the real parameter requirement.

2. Add method to make sure the export file extension is ".xml"

3. Fix the bug that ParserUtil#parseIndexList() splits input String into single figure.