### PR TITLE
[#52] ExportCommand: accept a range of index as parameter and fix bug

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -217,7 +217,8 @@ Exports persons identified by the index numbers used in the last person listing 
 Format: `export INDEXES ; FILE_PATH` +
 
 ****
-* The indexes refers to the index number shown in the most recent listing, and must be positive numbers separated by whitespaces or commas (,).
+* The indexes must be positive numbers or two indexes linked by "-" (e. g. "1-4"), and they should be separated by whitespaces or commas (e.g. 1-3, 4 6).
+* The indexes refers to the index number shown in the most recent listing.
 * `INDEXES` and `FILE_PATH` must be separated by ";".
 * If the given file exsits, it will be overwritten without warning.
 * The persons are exported to a XML format file, so a `.xml` extension will be automatically added, if the given file does not have one.
@@ -227,8 +228,8 @@ Format: `export INDEXES ; FILE_PATH` +
 Examples:
 
 * `list` +
-`export 1, 2 3; Persons.xml` +
-Exports 1st, 2nd and 3rd person in the address book to `Persons.xml` in the current working directory.
+`export 1-3, 5; Persons.xml` +
+Exports 1st, 2nd, 3rd and 5th person in the address book to `Persons.xml` in the current working directory.
 
 Since v1.1.
 

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -388,6 +388,21 @@ public class AutoComplete {
     }
 
     /**
+     * Formats the argument into range index list form.
+     */
+    private static String formatRangeIndexString(String arg) {
+        String numString = arg.replaceAll("((?!\\d|-).)+", "");
+        Matcher rangeIndexMatcher = Pattern.compile("(?<first>\\d+)-(?<second>\\d+).*").matcher(numString);
+        if (rangeIndexMatcher.matches()) { // range index
+            int firstNum = Integer.parseInt(rangeIndexMatcher.group("first"));
+            int secondNum = Integer.parseInt(rangeIndexMatcher.group("second"));
+            return Math.min(firstNum, secondNum) + "-" + Math.max(firstNum, secondNum);
+        } else { // single index, including number only on one side of '-'
+            return numString.replaceAll("\\D+", "");
+        }
+    }
+
+    /**
      * Formats the suggestion {@code String} of possible commands.
      */
     private static String promptForPossibleCommand(List<String> possibleCommands) {

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -338,8 +338,9 @@ public class AutoComplete {
         case PREFIX_PHONE_STRING:
             return prefix.getPrefix() + ParserUtil.parsePhone(firstArg).map(p -> p.value).orElse("");
         case PREFIX_TAG_STRING:
-            return ParserUtil.parseTags(argList).stream().map(p -> (prefix + p.tagName))
+            String tagString = ParserUtil.parseTags(argList).stream().map(p -> (prefix + p.tagName))
                 .collect(Collectors.joining(" "));
+            return tagString.isEmpty() ? PREFIX_TAG_STRING : tagString;
         case PREFIX_REMARK_STRING:
             return prefix.getPrefix() + firstArg.get().trim();
         case PREFIX_USERNAME_STRING:

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -188,8 +188,12 @@ public class AutoComplete {
         }
 
         // format Index List
-        possibleIndexListString = Arrays.stream(possibleIndexListString.split("(\\s|,)+"))
-            .map(AutoComplete::formatSingleIndexString).filter(p -> !p.isEmpty()).collect(Collectors.joining(", "));
+        try {
+            possibleIndexListString = wrapRangeIndexList(ParserUtil.parseRangeIndexList(possibleIndexListString));
+        } catch (IllegalValueException ive) {
+            possibleIndexListString = Arrays.stream(possibleIndexListString.split("(\\s|,)+"))
+                .map(AutoComplete::formatRangeIndexString).filter(p -> !p.isEmpty()).collect(Collectors.joining(", "));
+        }
 
         // format file path
         possibleFilePath = possibleFilePath.trim();

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -24,6 +24,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME_STRING;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -400,6 +401,42 @@ public class AutoComplete {
         } else { // single index, including number only on one side of '-'
             return numString.replaceAll("\\D+", "");
         }
+    }
+
+    /**
+     * Wraps the Index list by range index.
+     */
+    private static String wrapRangeIndexList(List<Index> indexList) {
+        if (indexList.isEmpty()) {
+            return "";
+        }
+        List<Integer> oneBasedIndexList = indexList.stream().map(Index::getOneBased).collect(Collectors.toList());
+        Collections.sort(oneBasedIndexList);
+
+        List<List<Integer>> splitList = new ArrayList<>();
+        List<Integer> currentList = new ArrayList<>();
+        for (int i = 0; i < oneBasedIndexList.size() - 1; i++) {
+            currentList.add(oneBasedIndexList.get(i));
+            if (oneBasedIndexList.get(i + 1) != oneBasedIndexList.get(i) + 1) {
+                splitList.add(currentList);
+                currentList = new ArrayList<>();
+            }
+        }
+        currentList.add(oneBasedIndexList.get(oneBasedIndexList.size() - 1));
+        splitList.add(currentList);
+
+        List<String> oneBasedRangeIndexStrings = new ArrayList<>();
+        for (List<Integer> oneBasedRangeIndex : splitList) {
+            if (oneBasedRangeIndex.size() == 1) { // single index
+                oneBasedRangeIndexStrings.add(String.valueOf(oneBasedRangeIndex.get(0)));
+            } else {
+                int first = oneBasedRangeIndex.get(0);
+                int last = oneBasedRangeIndex.get(oneBasedRangeIndex.size() - 1);
+                oneBasedRangeIndexStrings.add(first + "-" + last);
+            }
+        }
+
+        return oneBasedRangeIndexStrings.stream().collect(Collectors.joining(", "));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -167,18 +167,23 @@ public class AutoComplete {
      * Auto-completes export command.
      */
     private static String exportCommandAutoComplete(String args) {
-        Pattern exportPattern = Pattern.compile("(?<possibleIndexList>.[^;]);(?<possibleFilePath>.*)");
-        Matcher matcher = exportPattern.matcher(args);
+        if (args.trim().isEmpty()) {
+            return ExportCommand.COMMAND_WORD + " ";
+        }
 
         String possibleIndexListString;
-        String possibleFilePath;
-        if (matcher.matches()) { // contains delimiter ";"
-            possibleIndexListString = matcher.group("possibleIndexList");
-            possibleFilePath = matcher.group("possibleFilePath");
+        String possibleFilePath = "";
+        if (args.contains(";")) { // contains delimiter ";"
+            possibleIndexListString = args.substring(0, args.indexOf(';'));
+            possibleFilePath = args.substring(args.indexOf(';') + 1);
         } else { // try to find the index part and file part
             int possibleDelimiterIndex = Math.max(args.lastIndexOf(' '), args.lastIndexOf(','));
             possibleIndexListString = args.substring(0, possibleDelimiterIndex);
-            possibleFilePath = args.substring(possibleDelimiterIndex + 1);
+            if (possibleIndexListString.trim().isEmpty()) { // the only argument should be index
+                possibleIndexListString = args;
+            } else { // the last argument should be filePath
+                possibleFilePath = args.substring(possibleDelimiterIndex + 1);
+            }
         }
 
         // format Index List

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -21,8 +21,9 @@ public class ExportCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Exports persons identified by the index numbers used in the last person listing to a specified save file."
-        + "\n" + "Parameters: INDEXES; FILE_PATH (Indexes must be positive integers separated by commas or spaces)\n"
-        + "Example: " + COMMAND_WORD + " 1, 2 3; /Users/[User Name]/Desktop/persons.xml";
+        + "\n" + "Parameters: INDEXES; FILE_PATH\n"
+        + "(Indexes must be positive integers or two indexes linked by \"-\" separated by commas or spaces)\n"
+        + "Example: " + COMMAND_WORD + " 1-3, 4 6; /Users/[User Name]/Desktop/persons.xml";
 
     public static final String MESSAGE_EXPORT_PERSON_SUCCESS = "Your contacts: %1$shave been exported to file: %2$s";
 

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -35,7 +35,7 @@ public class ExportCommandParser implements Parser<ExportCommand> {
         // parse indexes
         List<Index> indexes;
         try {
-            indexes = ParserUtil.parseIndexList(oneBasedIndexListString);
+            indexes = ParserUtil.parseRangeIndexList(oneBasedIndexListString);
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -20,7 +20,7 @@ public class ExportCommandParser implements Parser<ExportCommand> {
     public static final String MISSING_FILE_PATH = "Missing file path!\n";
 
     private static final Pattern INDEXES_AND_FILEPATH =
-        Pattern.compile("(?<oneBasedIndexListString>.(((\\d)*(,)*(\\s)*)+));(?<filePath>.*)");
+        Pattern.compile("(?<oneBasedIndexListString>.(((\\d)*(,)*(\\s)*(-)*)+));(?<filePath>.*)");
 
     @Override
     public ExportCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,11 +3,14 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -58,6 +61,47 @@ public class ParserUtil {
             if (!s.trim().isEmpty()) {
                 indexes.add(parseIndex(s));
             }
+        }
+        return indexes;
+    }
+
+    /**
+     * Parses a {@code String} of one-based indexes that may contain single or range indexes into a {@code Set}.
+     * Indexes must be separated by "," or whitespaces, and index range must be linked by "-".
+     * @throws IllegalValueException if indexes are invalid, or the input {@code String} is not in valid format.
+     */
+    public static Set<Index> parseRangeIndexList(String oneBasedIndexList) throws IllegalValueException {
+        oneBasedIndexList = oneBasedIndexList.replaceAll("\\s*-\\s*", "-");
+        List<String> filteredIndexStrings = Arrays.stream(oneBasedIndexList.split("(,+)|(\\s+)"))
+            .map(String::trim)
+            .filter(((Predicate<String>) String::isEmpty).negate())
+            .collect(Collectors.toList());
+
+        Set<Integer> oneBasedIndexSet = new HashSet<>();
+        for (String s : filteredIndexStrings) {
+            if (s.matches("^(\\d+)-(\\d+)$")) {
+                oneBasedIndexSet.addAll(parseRangeIndex(s));
+            } else if (s.matches("^(\\d+)$")) {
+                oneBasedIndexSet.add(Integer.parseInt(s));
+            } else {
+                throw new IllegalValueException("");
+            }
+        }
+        return oneBasedIndexSet.stream().map(Index::fromOneBased).collect(Collectors.toSet());
+    }
+
+    /**
+     * Parses a {@code oneBasedRangeIndex} into a List of {@code Index}.
+     */
+    private static List<Integer> parseRangeIndex(String oneBasedRangeIndex) {
+        int separatorIndex = oneBasedRangeIndex.indexOf('-');
+        int firstIndex = Integer.parseInt(oneBasedRangeIndex.substring(0, separatorIndex).trim());
+        int secondIndex = Integer.parseInt(oneBasedRangeIndex.substring(separatorIndex + 1).trim());
+        int start = Math.min(firstIndex, secondIndex);
+        int end = Math.max(firstIndex, secondIndex);
+        List<Integer> indexes = new ArrayList<>();
+        for (Integer i = start; i <= end; i++) {
+            indexes.add(i);
         }
         return indexes;
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -50,27 +50,11 @@ public class ParserUtil {
     }
 
     /**
-     * Parsers {@code oneBasedIndexList} into a List of {@code Index} and returns it.
-     * The numbers must be separated by whitespaces or ",".
-     * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
-     */
-    public static List<Index> parseIndexList(String oneBasedIndexList) throws IllegalValueException {
-        String[] indexStrings = oneBasedIndexList.split("((,)|(\\s))+");
-        List<Index> indexes = new ArrayList<>();
-        for (String s : indexStrings) {
-            if (!s.trim().isEmpty()) {
-                indexes.add(parseIndex(s));
-            }
-        }
-        return indexes;
-    }
-
-    /**
      * Parses a {@code String} of one-based indexes that may contain single or range indexes into a {@code Set}.
      * Indexes must be separated by "," or whitespaces, and index range must be linked by "-".
      * @throws IllegalValueException if indexes are invalid, or the input {@code String} is not in valid format.
      */
-    public static Set<Index> parseRangeIndexList(String oneBasedIndexList) throws IllegalValueException {
+    public static List<Index> parseRangeIndexList(String oneBasedIndexList) throws IllegalValueException {
         oneBasedIndexList = oneBasedIndexList.replaceAll("\\s*-\\s*", "-");
         List<String> filteredIndexStrings = Arrays.stream(oneBasedIndexList.split("(,+)|(\\s+)"))
             .map(String::trim)
@@ -87,7 +71,7 @@ public class ParserUtil {
                 throw new IllegalValueException(MESSAGE_INVALID_INDEX);
             }
         }
-        return oneBasedIndexSet.stream().map(Index::fromOneBased).collect(Collectors.toSet());
+        return oneBasedIndexSet.stream().map(Index::fromOneBased).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -84,7 +84,7 @@ public class ParserUtil {
             } else if (s.matches("^(\\d+)$")) {
                 oneBasedIndexSet.add(Integer.parseInt(s));
             } else {
-                throw new IllegalValueException("");
+                throw new IllegalValueException(MESSAGE_INVALID_INDEX);
             }
         }
         return oneBasedIndexSet.stream().map(Index::fromOneBased).collect(Collectors.toSet());

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -71,7 +71,15 @@ public class ParserUtil {
                 throw new IllegalValueException(MESSAGE_INVALID_INDEX);
             }
         }
-        return oneBasedIndexSet.stream().map(Index::fromOneBased).collect(Collectors.toList());
+
+        List<Index> indexList = new ArrayList<>();
+        for (int index : oneBasedIndexSet) {
+            if (index <= 0) {
+                throw new IllegalValueException(MESSAGE_INVALID_INDEX);
+            }
+            indexList.add(Index.fromOneBased(index));
+        }
+        return indexList;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -182,19 +182,47 @@ public class AutoCompleteTest {
     }
 
     @Test
+    public void autoCompleteExport_noArg_trimSpaces() {
+        String command = "export    ";
+        String expected = "export ";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
     public void autoCompleteExport_invalidIndexes_trimNonDigitChars() {
         String command = "export 1a 2a,, 3*.;   SomeFile.xml ";
         String expected = "export 1, 2, 3; SomeFile.xml";
+        assertAutoComplete(command, expected);
+
+        command = "export a1-3-10a,4 6aa ,,  ; SomeFile.xml";
+        expected = "export 1-3, 4, 6; SomeFile.xml";
         assertAutoComplete(command, expected);
     }
 
     @Test
     public void autoCompleteExport_noDelimiter_trimNonDigitChars() {
         String command = "export 1, 2, 3 SomeFile.xml ";
-        String expected = "export 1, 2, 3; SomeFile.xml";
+        String expected = "export 1-3; SomeFile.xml";
         assertAutoComplete(command, expected);
 
         command = "export 1, 2, 3,SomeFile.xml ";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteExport_continuousIndexes_wrapContinuousIndexes() {
+        String command = "export 1, 2, 3, 4; SomeFile.xml ";
+        String expected = "export 1-4; SomeFile.xml";
+        assertAutoComplete(command, expected);
+
+        command = "export 1-3, 4; SomeFile.xml ";
+        assertAutoComplete(command, expected);
+
+        command = "export 3-1, 4; SomeFile.xml ";
+        assertAutoComplete(command, expected);
+
+        command = "export 1,2,3,6,10,12,11; SomeFile.xml ";
+        expected = "export 1-3, 6, 10-12; SomeFile.xml";
         assertAutoComplete(command, expected);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -43,7 +43,7 @@ public class ExportCommandParserTest {
 
     @Test
     public void parse_invalidIndex_failure() {
-        String input = "1, 2 3-4 ; " + VALID_FILE_PATH;
+        String input = "1, 2 3-4 a; " + VALID_FILE_PATH;
         assertParseFailure(parser, input, EXPECTED_MATCH_ERROR_MESSAGE);
 
         String negativeIndexInput = "-1 ; " + VALID_FILE_PATH;
@@ -77,6 +77,11 @@ public class ExportCommandParserTest {
         List<Index> indexes = getIndexListFromOneBasedArray(1, 2, 3);
         String input = "1, 2 3 ; " + VALID_FILE_PATH;
         ExportCommand exportCommand = new ExportCommand(indexes, VALID_FILE_PATH.trim());
+        assertParseSuccess(parser, input, exportCommand);
+
+        indexes = getIndexListFromOneBasedArray(1, 2, 3, 5, 7, 8, 9);
+        input = "1, 2, 3 5 7-9;" + VALID_FILE_PATH;
+        exportCommand = new ExportCommand(indexes, VALID_FILE_PATH.trim());
         assertParseSuccess(parser, input, exportCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -75,6 +75,13 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseRangeIndexList_outOfBoundaryIndex_throwsIllegalValueException() throws Exception {
+        thrown.expect(IllegalValueException.class);
+        thrown.expectMessage(MESSAGE_INVALID_INDEX);
+        ParserUtil.parseRangeIndexList("0-3");
+    }
+
+    @Test
     public void parseRangeIndexList_validRange_success() throws Exception {
         // one range index
         assertEqualsIndexCollection(INDEX_LIST_FIRST_TO_THIRD, ParserUtil.parseRangeIndexList("1-3"));

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -10,15 +10,18 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_LIST_FIRST_TO_THIRD;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -75,6 +78,28 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces and ","s
         assertEquals(INDEX_LIST_FIRST_TO_THIRD, parseIndexList("  ,, ,1, 2 3  ,,"));
+    }
+
+    @Test
+    public void parseRangeIndexList_invalidInput_throwsIllegalValueException() throws Exception {
+        thrown.expect(IllegalValueException.class);
+        thrown.expectMessage(MESSAGE_INVALID_INDEX);
+        ParserUtil.parseRangeIndexList("1-3, a");
+    }
+
+    @Test
+    public void parseRangeIndexList_validRange_success() throws Exception {
+        // one range index
+        assertEqualsIndexCollection(INDEX_LIST_FIRST_TO_THIRD, ParserUtil.parseRangeIndexList("1-3"));
+
+        // multiple range indexes
+        assertEqualsIndexCollection(INDEX_LIST_FIRST_TO_THIRD, ParserUtil.parseRangeIndexList("1, 2-3"));
+    }
+
+    private void assertEqualsIndexCollection(Collection<Index> set1, Collection<Index> set2) {
+        Set<Integer> integerSet1 = set1.stream().map(Index::getZeroBased).collect(Collectors.toSet());
+        Set<Integer> integerSet2 = set2.stream().map(Index::getZeroBased).collect(Collectors.toSet());
+        assertEquals(integerSet1, integerSet2);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.logic.parser.ParserUtil.parseIndexList;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_LIST_FIRST_TO_THIRD;
 
@@ -66,18 +65,6 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
-    }
-
-    @Test
-    public void parseIndexList_validInput_success() throws Exception {
-        // separated by whitespaces
-        assertEquals(INDEX_LIST_FIRST_TO_THIRD, ParserUtil.parseIndexList("1 2 3"));
-
-        // separated by ","
-        assertEquals(INDEX_LIST_FIRST_TO_THIRD, parseIndexList("1, 2, 3"));
-
-        // Leading and trailing whitespaces and ","s
-        assertEquals(INDEX_LIST_FIRST_TO_THIRD, parseIndexList("  ,, ,1, 2 3  ,,"));
     }
 
     @Test


### PR DESCRIPTION
- Fix the issue that export command will not throw exception when no argument is passed.
- Update export command parser to accept a range of indexes in form of "1-4".
- Update auto-complete to wrap continuous indexes. (eg. "1, 2, 3, 5" -> "1-3, 5")
- Update corresponding documents.