### PR TITLE
[#46] Facebook field

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -73,8 +73,11 @@ Format:
 === Adding a person: `add`
 
 Adds a person to the address book +
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL [a/ADDRESS] [b/BIRTHDAY] [t/TAG]...` +
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL [a/ADDRESS] [b/BIRTHDAY] [f/FACEBOOK] [t/TAG]...` +
 Shorthand for add: `a`
+
+[NOTE]
+Facebook represents a person's Facebook ID (a long number), rather than the Facebook username.
 
 [TIP]
 A person can have any number of tags (including 0)
@@ -82,7 +85,7 @@ A person can have any number of tags (including 0)
 Examples:
 
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal`
+* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 f/153080620724s t/criminal`
 
 === Listing all persons : `list`
 
@@ -106,7 +109,7 @@ Examples:
 === Editing a person : `edit`
 
 Edits an existing person in the address book. +
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [t/TAG]...` +
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [f/FACEBOOK] [t/TAG]...` +
 Shorthand for edit: `e`
 
 ****

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -9,6 +9,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL_STRING;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
@@ -111,13 +113,14 @@ public class AutoComplete {
      */
     private static String addCommandAutoComplete(String args) {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
-            PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_BIRTHDAY, PREFIX_TAG);
+            PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_BIRTHDAY, PREFIX_FACEBOOK, PREFIX_TAG);
         return AddCommand.COMMAND_WORD + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_NAME) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_PHONE) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_BIRTHDAY) + " "
+            + formatPrefixWithArgs(argMultimap, PREFIX_FACEBOOK) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_TAG);
     }
 
@@ -133,7 +136,7 @@ public class AutoComplete {
      */
     private static String editCommandAutoComplete(String args, List<ReadOnlyPerson> filteredPersonList) {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
-            PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_BIRTHDAY, PREFIX_TAG);
+            PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_BIRTHDAY, PREFIX_FACEBOOK, PREFIX_TAG);
 
         String indexString = argMultimap.getPreamble();
         Index index;
@@ -154,6 +157,7 @@ public class AutoComplete {
                 + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL, person) + " "
                 + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS, person) + " "
                 + formatPrefixWithArgs(argMultimap, PREFIX_BIRTHDAY, person) + " "
+                + formatPrefixWithArgs(argMultimap, PREFIX_FACEBOOK, person) + " "
                 + formatPrefixWithArgs(argMultimap, PREFIX_TAG, person);
         } catch (IndexOutOfBoundsException e) {
             String restArgs = args.replaceFirst(indexString, "").trim();
@@ -328,6 +332,8 @@ public class AutoComplete {
             return prefix.getPrefix() + ParserUtil.parseBirthday(firstArg).map(p -> p.value).orElse("");
         case PREFIX_EMAIL_STRING:
             return prefix.getPrefix() + ParserUtil.parseEmail(firstArg).map(p -> p.value).orElse("");
+        case PREFIX_FACEBOOK_STRING:
+            return prefix.getPrefix() + ParserUtil.parseFacebook(firstArg).map(p -> p.value).orElse("");
         case PREFIX_NAME_STRING:
             return prefix.getPrefix() + ParserUtil.parseName(firstArg).map(p -> p.fullName).orElse("");
         case PREFIX_PHONE_STRING:
@@ -365,6 +371,8 @@ public class AutoComplete {
             return person.getAddress().value;
         case PREFIX_BIRTHDAY_STRING:
             return person.getBirthday().value;
+        case PREFIX_FACEBOOK_STRING:
+            return  person.getFacebook().value;
         case PREFIX_REMARK_STRING:
             return person.getRemark().value;
         case PREFIX_TAG_STRING:

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -28,6 +29,7 @@ public class AddCommand extends UndoableCommand {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + PREFIX_BIRTHDAY + "BIRTHDAY "
+            + "[" + PREFIX_FACEBOOK + "FACEBOOK]"
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
@@ -35,6 +37,7 @@ public class AddCommand extends UndoableCommand {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_BIRTHDAY + "1997/11/30"
+            + PREFIX_FACEBOOK + "4"
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -20,6 +21,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -45,6 +47,7 @@ public class EditCommand extends UndoableCommand {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_BIRTHDAY + "BIRTHDAY] "
+            + "[" + PREFIX_FACEBOOK + "FACEBOOK] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -104,9 +107,11 @@ public class EditCommand extends UndoableCommand {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Birthday updatedBirthday = editPersonDescriptor.getBirthday().orElse(personToEdit.getBirthday());
+        Facebook updatedFacebook = editPersonDescriptor.getFacebook().orElse(personToEdit.getFacebook());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthday, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthday,
+            updatedFacebook, updatedTags);
     }
 
     @Override
@@ -137,6 +142,7 @@ public class EditCommand extends UndoableCommand {
         private Email email;
         private Address address;
         private Birthday birthday;
+        private Facebook facebook;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -147,6 +153,7 @@ public class EditCommand extends UndoableCommand {
             this.email = toCopy.email;
             this.address = toCopy.address;
             this.birthday = toCopy.birthday;
+            this.facebook = toCopy.facebook;
             this.tags = toCopy.tags;
         }
 
@@ -155,7 +162,7 @@ public class EditCommand extends UndoableCommand {
          */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(this.name, this.phone, this.email, this.address, this.birthday,
-                    this.tags);
+                    this.facebook, this.tags);
         }
 
         public void setName(Name name) {
@@ -198,6 +205,14 @@ public class EditCommand extends UndoableCommand {
             return Optional.ofNullable(birthday);
         }
 
+        public void setFacebook(Facebook facebook) {
+            this.facebook = facebook;
+        }
+
+        public Optional<Facebook> getFacebook() {
+            return Optional.ofNullable(facebook);
+        }
+
         public void setTags(Set<Tag> tags) {
             this.tags = tags;
         }
@@ -226,6 +241,7 @@ public class EditCommand extends UndoableCommand {
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())
                     && getBirthday().equals(e.getBirthday())
+                    && getFacebook().equals(e.getFacebook())
                     && getTags().equals(e.getTags());
         }
     }

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -89,9 +90,10 @@ public class RemarkCommand extends UndoableCommand {
         Email email = personToAddRemarkTo.getEmail();
         Address address = personToAddRemarkTo.getAddress();
         Birthday birthday = personToAddRemarkTo.getBirthday();
+        Facebook facebook = personToAddRemarkTo.getFacebook();
         Set<Tag> tags = personToAddRemarkTo.getTags();
 
-        Person personWithRemark = new Person(name, phone, email, address, birthday, tags);
+        Person personWithRemark = new Person(name, phone, email, address, birthday, facebook, tags);
         personWithRemark.setRemark(rmk);
 
         return personWithRemark;

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -17,6 +18,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -36,7 +38,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_BIRTHDAY, PREFIX_TAG);
+                        PREFIX_BIRTHDAY, PREFIX_FACEBOOK, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
@@ -53,9 +55,11 @@ public class AddCommandParser implements Parser<AddCommand> {
                 .orElse(Address.getEmptyAddress());
             Birthday birthday = ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY))
                 .orElse(Birthday.getEmptyBirthday());
+            Facebook facebook = ParserUtil.parseFacebook(argMultimap.getValue(PREFIX_FACEBOOK))
+                .orElse(Facebook.getEmptyFacebook());
             Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-            ReadOnlyPerson person = new Person(name, phone, email, address, birthday, tagList);
+            ReadOnlyPerson person = new Person(name, phone, email, address, birthday, facebook, tagList);
 
             return new AddCommand(person);
         } catch (IllegalValueException ive) {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,6 +12,7 @@ public class CliSyntax {
     public static final String PREFIX_EMAIL_STRING = "e/";
     public static final String PREFIX_ADDRESS_STRING = "a/";
     public static final String PREFIX_BIRTHDAY_STRING = "b/";
+    public static final String PREFIX_FACEBOOK_STRING = "f/";
     public static final String PREFIX_TAG_STRING = "t/";
     public static final String PREFIX_REMARK_STRING = "r/";
     public static final String PREFIX_USERNAME_STRING = "usr/";
@@ -25,6 +26,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix(PREFIX_EMAIL_STRING);
     public static final Prefix PREFIX_ADDRESS = new Prefix(PREFIX_ADDRESS_STRING);
     public static final Prefix PREFIX_BIRTHDAY = new Prefix(PREFIX_BIRTHDAY_STRING);
+    public static final Prefix PREFIX_FACEBOOK = new Prefix(PREFIX_FACEBOOK_STRING);
     public static final Prefix PREFIX_TAG = new Prefix(PREFIX_TAG_STRING);
     public static final Prefix PREFIX_REMARK = new Prefix(PREFIX_REMARK_STRING);
     public static final Prefix PREFIX_NAME_FOR_SORTING = new Prefix("name");

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -35,7 +36,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_BIRTHDAY, PREFIX_TAG);
+                        PREFIX_BIRTHDAY, PREFIX_FACEBOOK, PREFIX_TAG);
 
         Index index;
 
@@ -53,6 +54,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS)).ifPresent(editPersonDescriptor::setAddress);
             ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY))
                     .ifPresent(editPersonDescriptor::setBirthday);
+            ParserUtil.parseFacebook(argMultimap.getValue(PREFIX_FACEBOOK))
+                    .ifPresent(editPersonDescriptor::setFacebook);
             parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
         } catch (IllegalValueException ive) {
             throw new ParseException(ive.getMessage(), ive);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -15,6 +15,7 @@ import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -105,6 +106,15 @@ public class ParserUtil {
     public static Optional<Email> parseEmail(Optional<String> email) throws IllegalValueException {
         requireNonNull(email);
         return email.isPresent() ? Optional.of(new Email(email.get())) : Optional.empty();
+    }
+
+    /**
+     * Parses a {@code Optional<String> facebook} into an {@code Optional<Facebook>} if {@code facebook} is present.
+     * See header comment of this class regarding the use of {@code Optional} parameters.
+     */
+    public static Optional<Facebook> parseFacebook(Optional<String> facebook) throws IllegalValueException {
+        requireNonNull(facebook);
+        return facebook.isPresent() ? Optional.of(new Facebook(facebook.get())) : Optional.empty();
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/DetailsContainKeyphrasePredicate.java
+++ b/src/main/java/seedu/address/model/person/DetailsContainKeyphrasePredicate.java
@@ -39,10 +39,11 @@ public class DetailsContainKeyphrasePredicate implements Predicate<ReadOnlyPerso
         boolean emailContainsKeyphrase = StringUtil.caseInsensitiveContains(person.getEmail().value, keyphrase);
         boolean phoneContainsKeyphrase = StringUtil.caseInsensitiveContains(person.getPhone().value, keyphrase);
         boolean addressContainsKeyphrase = StringUtil.caseInsensitiveContains(person.getAddress().value, keyphrase);
+        boolean facebookContainsKeyphrase = StringUtil.caseInsensitiveContains(person.getFacebook().value, keyphrase);
         boolean remarkContainsKeyphrase = StringUtil.caseInsensitiveContains(person.getRemark().value, keyphrase);
         boolean tagContainsKeyphrase = StringUtil.caseInsensitiveContains(person.getTags().toString(), keyphrase);
 
         return nameContainsKeyphrase || emailContainsKeyphrase || phoneContainsKeyphrase || addressContainsKeyphrase
-                || remarkContainsKeyphrase || tagContainsKeyphrase;
+                || facebookContainsKeyphrase || remarkContainsKeyphrase || tagContainsKeyphrase;
     }
 }

--- a/src/main/java/seedu/address/model/person/Facebook.java
+++ b/src/main/java/seedu/address/model/person/Facebook.java
@@ -1,0 +1,75 @@
+//@@author HanYaodong
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+/**
+ * Represents a Person's Facebook ID in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidFacebookId(String)}
+ */
+public class Facebook {
+    public static final String MESSAGE_FACEBOOK_CONSTRAINTS =
+        "Person facebook should be in the format ";
+    public static final String FACEBOOK_ID_VALIDATION_REGEX = "\\d+";
+
+    public final String value;
+
+    /**
+     * Validates given facebook.
+     *
+     * @throws IllegalValueException if given facebook string is invalid.
+     */
+    public Facebook(String facebookId) throws IllegalValueException {
+        requireNonNull(facebookId);
+        if (facebookId.isEmpty()) {
+            this.value = "";
+            return;
+        }
+        String trimmedFacebookId = facebookId.trim();
+        if (!isValidFacebookId(trimmedFacebookId)) {
+            throw new IllegalValueException(MESSAGE_FACEBOOK_CONSTRAINTS);
+        }
+        this.value = trimmedFacebookId;
+    }
+
+    /**
+     * Creates Birthday that is empty.
+     */
+    private Facebook() {
+        this.value = "";
+    }
+
+    /**
+     * Returns if a given string is a valid person email.
+     */
+    public static boolean isValidFacebookId(String test) {
+        return test.matches(FACEBOOK_ID_VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns an empty Birthday object.
+     */
+    public static Facebook getEmptyFacebook() {
+        return new Facebook();
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof Facebook // instanceof handles nulls
+            && this.value.equals(((Facebook) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -23,19 +23,22 @@ public class Person implements ReadOnlyPerson {
     private ObjectProperty<Email> email;
     private ObjectProperty<Address> address;
     private ObjectProperty<Birthday> birthday;
+    private ObjectProperty<Facebook> facebook;
     private ObjectProperty<UniqueTagList> tags;
     private ObjectProperty<Remark> remark;
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Birthday birthday, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, Birthday birthday,
+                  Facebook facebook, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, birthday, tags);
         this.name = new SimpleObjectProperty<>(name);
         this.phone = new SimpleObjectProperty<>(phone);
         this.email = new SimpleObjectProperty<>(email);
         this.address = new SimpleObjectProperty<>(address);
         this.birthday = new SimpleObjectProperty<>(birthday);
+        this.facebook = new SimpleObjectProperty<>(facebook);
         // protect internal tags from changes in the arg list
         this.tags = new SimpleObjectProperty<>(new UniqueTagList(tags));
         this.remark = new SimpleObjectProperty<>(new Remark(""));
@@ -46,7 +49,7 @@ public class Person implements ReadOnlyPerson {
      */
     public Person(ReadOnlyPerson source) {
         this(source.getName(), source.getPhone(), source.getEmail(), source.getAddress(), source.getBirthday(),
-                source.getTags());
+               source.getFacebook(), source.getTags());
         this.remark = new SimpleObjectProperty<>(source.getRemark());
     }
 
@@ -120,6 +123,20 @@ public class Person implements ReadOnlyPerson {
         this.birthday.set(birthday);
     }
 
+    public void setFacebook(Facebook facebook) {
+        this.facebook.set(facebook);
+    }
+
+    @Override
+    public ObjectProperty<Facebook> facebookProperty() {
+        return facebook;
+    }
+
+    @Override
+    public Facebook getFacebook() {
+        return facebook.get();
+    }
+
     @Override
     public void setRemark(Remark remark) {
         this.remark.set(remark);
@@ -174,7 +191,7 @@ public class Person implements ReadOnlyPerson {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, birthday, facebook, tags);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -22,6 +22,8 @@ public interface ReadOnlyPerson {
     Address getAddress();
     ObjectProperty<Birthday> birthdayProperty();
     Birthday getBirthday();
+    ObjectProperty<Facebook> facebookProperty();
+    Facebook getFacebook();
     ObjectProperty<UniqueTagList> tagProperty();
     Set<Tag> getTags();
     ObjectProperty<Remark> remarkProperty();
@@ -45,6 +47,7 @@ public interface ReadOnlyPerson {
                 && other.getEmail().equals(this.getEmail())
                 && other.getAddress().equals(this.getAddress())
                 && other.getBirthday().equals(this.getBirthday())
+                && other.getFacebook().equals(this.getFacebook())
                 && other.getRemark().equals(this.getRemark()));
     }
 
@@ -62,6 +65,8 @@ public interface ReadOnlyPerson {
                 .append(getAddress())
                 .append(" Birthday: ")
                 .append(getBirthday())
+                .append(" Facebook: ")
+                .append(getFacebook())
                 .append(" Remark: ")
                 .append(getRemark())
                 .append(" Tags: ");

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -9,6 +9,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -24,24 +25,24 @@ public class SampleDataUtil {
         Person[] personList = new Person[6];
         try {
             personList[0] = new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                    new Address("Blk 30 Geylang Street 29, #06-40"), new Birthday("1991/01/22"),
+                    new Address("Blk 30 Geylang Street 29, #06-40"), new Birthday("1991/01/22"), new Facebook("4"),
                     getTagSet("friends"));
             personList[1] = new Person(new Name("Bernice Yu"), new Phone("99272758"),
                     new Email("berniceyu@example.com"),
                     new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Birthday("1990/10/20"),
-                    getTagSet("colleagues", "friends"));
+                    new Facebook("6815841748"), getTagSet("colleagues", "friends"));
             personList[2] = new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                     new Email("charlotte@example.com"), new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                    new Birthday("1890/03/20"), getTagSet("neighbours"));
+                    new Birthday("1890/03/20"), new Facebook("153080620724"), getTagSet("neighbours"));
             personList[3] = new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Birthday("1999/01/01"),
-                    getTagSet("family"));
+                    new Facebook("771663635"), getTagSet("family"));
             personList[4] = new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                    new Address("Blk 47 Tampines Street 20, #17-35"), new Birthday("2000/01/31"),
+                    new Address("Blk 47 Tampines Street 20, #17-35"), new Birthday("2000/01/31"), new Facebook("5"),
                     getTagSet("classmates"));
             personList[5] = new Person(new Name("Roy Balakrishnan"), new Phone("92624417"),
                     new Email("royb@example.com"), new Address("Blk 45 Aljunied Street 85, #11-31"),
-                    new Birthday("2001/07/07"), getTagSet("colleagues"));
+                    new Birthday("2001/07/07"), new Facebook("6"), getTagSet("colleagues"));
         } catch (IllegalValueException e) {
             throw new AssertionError("sample data cannot be invalid", e);
         }

--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -11,6 +11,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -33,6 +34,8 @@ public class XmlAdaptedPerson {
     private String address;
     @XmlElement(required = true)
     private String birthday;
+    @XmlElement(required = true)
+    private String facebook;
     @XmlElement(required = true)
     private String remark;
 
@@ -57,6 +60,7 @@ public class XmlAdaptedPerson {
         email = source.getEmail().value;
         address = source.getAddress().value;
         birthday = source.getBirthday().value;
+        facebook = source.getFacebook().value;
         remark = source.getRemark().value;
         tagged = new ArrayList<>();
         for (Tag tag : source.getTags()) {
@@ -79,9 +83,10 @@ public class XmlAdaptedPerson {
         final Email email = new Email(this.email);
         final Address address = new Address(this.address);
         final Birthday birthday = new Birthday(this.birthday);
+        final Facebook facebook = new Facebook(this.facebook);
         final Remark remark = new Remark(this.remark);
         final Set<Tag> tags = new HashSet<>(personTags);
-        Person person = new Person(name, phone, email, address, birthday, tags);
+        Person person = new Person(name, phone, email, address, birthday, facebook, tags);
         person.setRemark(remark);
 
         return person;

--- a/src/main/java/seedu/address/ui/PersonProfile.java
+++ b/src/main/java/seedu/address/ui/PersonProfile.java
@@ -73,11 +73,10 @@ public class PersonProfile extends UiPart<Region> {
      * Retrieves a profile picture from Facebook {@see Facebook#getPictureURL}and sets that image as the contact image
      * for the Person's profile. A default image would be assigned if no picture is retrieved from Facebook.
      */
-    private void setProfilePicture() {
+    private void setProfilePicture(ReadOnlyPerson person) {
         Image profilePic;
         try {
-            // TODO: Replace hardcoded userID with Dynamically get Facebook userId
-            profilePic = new Image(facebook.getPictureURL("1253844668", PictureSize.large).toString());
+            profilePic = new Image(facebook.getPictureURL(person.getFacebook().value, PictureSize.large).toString());
         } catch (FacebookException fbe) {
             profilePic = new Image(defaultProfilePicture);
             fbe.printStackTrace();
@@ -88,8 +87,9 @@ public class PersonProfile extends UiPart<Region> {
     @Subscribe
     private void handlePersonPanelSelectionChangedEvent(PersonPanelSelectionChangedEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        initPersonProfile(event.getNewSelection().person);
-        setProfilePicture();
+        ReadOnlyPerson selectedPerson = event.getNewSelection().person;
+        initPersonProfile(selectedPerson);
+        setProfilePicture(selectedPerson);
     }
 
     @Override

--- a/src/test/data/ImportCommandSystemTest/Amy.xml
+++ b/src/test/data/ImportCommandSystemTest/Amy.xml
@@ -7,6 +7,7 @@
         <email>amy@example.com</email>
         <address>Block 312, Amy Street 1</address>
         <birthday>2000/10/10</birthday>
+        <facebook>21</facebook>
         <remark></remark>
         <tagged>friend</tagged>
     </persons>

--- a/src/test/data/ImportCommandSystemTest/DuplicatedPersonInAddressBook.xml
+++ b/src/test/data/ImportCommandSystemTest/DuplicatedPersonInAddressBook.xml
@@ -7,6 +7,7 @@
         <email>johnd@example.com</email>
         <address>311, Clementi Ave 2, #02-25</address>
         <birthday>2000/02/02</birthday>
+        <facebook>5</facebook>
         <remark></remark>
         <tagged>owesMoney</tagged>
         <tagged>friends</tagged>
@@ -17,6 +18,7 @@
         <email>james@example.com</email>
         <address>Sydney</address>
         <birthday>2000/01/01</birthday>
+        <facebook>30</facebook>
         <remark></remark>
         <tagged>friends</tagged>
     </persons>

--- a/src/test/data/ImportCommandSystemTest/DuplicatedPersonsExportFile.xml
+++ b/src/test/data/ImportCommandSystemTest/DuplicatedPersonsExportFile.xml
@@ -7,6 +7,7 @@
         <email>hans@example.com</email>
         <address>chicago ave</address>
         <birthday>2000/01/01</birthday>
+        <facebook>12</facebook>
         <remark></remark>
         <tagged>friends</tagged>
     </persons>
@@ -16,6 +17,7 @@
         <email>hans@example.com</email>
         <address>chicago ave</address>
         <birthday>2000/01/01</birthday>
+        <facebook>12</facebook>
         <remark></remark>
         <tagged>friends</tagged>
     </persons>

--- a/src/test/data/ImportCommandSystemTest/Hoon_Bob.xml
+++ b/src/test/data/ImportCommandSystemTest/Hoon_Bob.xml
@@ -7,6 +7,7 @@
         <email>stefan@example.com</email>
         <address>little india</address>
         <birthday>2000/08/08</birthday>
+        <facebook>11</facebook>
         <tagged>friends</tagged>
         <remark></remark>
     </persons>
@@ -16,6 +17,7 @@
         <email>bob@example.com</email>
         <address>Block 123, Bobby Street 3</address>
         <birthday>1999/10/10</birthday>
+        <facebook>20</facebook>
         <remark></remark>
         <tagged>friend</tagged>
         <tagged>husband</tagged>

--- a/src/test/data/ImportCommandTest/DuplicatedPersonInAddressBook.xml
+++ b/src/test/data/ImportCommandTest/DuplicatedPersonInAddressBook.xml
@@ -7,6 +7,7 @@
         <email>johnd@example.com</email>
         <address>311, Clementi Ave 2, #02-25</address>
         <birthday>2000/02/02</birthday>
+        <facebook>5</facebook>
         <remark></remark>
         <tagged>owesMoney</tagged>
         <tagged>friends</tagged>

--- a/src/test/data/ImportCommandTest/DuplicatedPersonsExportFile.xml
+++ b/src/test/data/ImportCommandTest/DuplicatedPersonsExportFile.xml
@@ -7,6 +7,7 @@
         <email>stefan@example.com</email>
         <address>little india</address>
         <birthday>2000/01/01</birthday>
+        <facebook>11</facebook>
         <remark></remark>
         <tagged>friend</tagged>
     </persons>
@@ -16,6 +17,7 @@
         <email>stefan@example.com</email>
         <address>little india</address>
         <birthday>2000/01/01</birthday>
+        <facebook>11</facebook>
         <remark></remark>
         <tagged>friend</tagged>
     </persons>

--- a/src/test/data/ImportCommandTest/ImportTestFile.xml
+++ b/src/test/data/ImportCommandTest/ImportTestFile.xml
@@ -7,6 +7,7 @@
         <email>stefan@example.com</email>
         <address>little india</address>
         <birthday>2000/08/08</birthday>
+        <facebook>11</facebook>
         <remark></remark>
     </persons>
 </personList>

--- a/src/test/data/XmlPersonListStorageTest/DuplicatedPersonsList.xml
+++ b/src/test/data/XmlPersonListStorageTest/DuplicatedPersonsList.xml
@@ -7,6 +7,7 @@
         <email>johnd@example.com</email>
         <address>311, Clementi Ave 2, #02-25</address>
         <birthday>2000/02/02</birthday>
+        <facebook>5</facebook>
         <remark></remark>
         <tagged>owesMoney</tagged>
         <tagged>friends</tagged>
@@ -17,6 +18,7 @@
         <email>johnd@example.com</email>
         <address>311, Clementi Ave 2, #02-25</address>
         <birthday>2000/02/02</birthday>
+        <facebook>5</facebook>
         <remark></remark>
         <tagged>owesMoney</tagged>
         <tagged>friends</tagged>

--- a/src/test/data/XmlUtilTest/validAddressBook.xml
+++ b/src/test/data/XmlUtilTest/validAddressBook.xml
@@ -6,6 +6,7 @@
         <email isPrivate="false">hans@example.com</email>
         <address isPrivate="false">4th street</address>
         <birthday isPrivate="false">2000/01/01</birthday>
+        <facebook isPrivate="false">4</facebook>
         <remark isPrivate="false">likes pineapple</remark>
 
     </persons>
@@ -15,6 +16,7 @@
         <email isPrivate="false">ruth@example.com</email>
         <address isPrivate="false">81th street</address>
         <birthday isPrivate="false">2000/02/02</birthday>
+        <facebook isPrivate="false">5</facebook>
         <remark isPrivate="false">likes coffee</remark>
     </persons>
     <persons>
@@ -23,6 +25,7 @@
         <email isPrivate="false">heinz@example.com</email>
         <address isPrivate="false">wall street</address>
         <birthday isPrivate="false">2000/03/03</birthday>
+        <facebook isPrivate="false">6</facebook>
         <remark isPrivate="false">likes milk tea</remark>
     </persons>
     <persons>
@@ -31,6 +34,7 @@
         <email isPrivate="false">cornelia@example.com</email>
         <address isPrivate="false">10th street</address>
         <birthday isPrivate="false">2000/04/04</birthday>
+        <facebook isPrivate="false">7</facebook>
         <remark isPrivate="false">likes dragon fruit</remark>
     </persons>
     <persons>
@@ -39,6 +43,7 @@
         <email isPrivate="false">werner@example.com</email>
         <address isPrivate="false">michegan ave</address>
         <birthday isPrivate="false">2000/05/05</birthday>
+        <facebook isPrivate="false">8</facebook>
         <remark isPrivate="false">likes dolphins</remark>
     </persons>
     <persons>
@@ -47,6 +52,7 @@
         <email isPrivate="false">lydia@example.com</email>
         <address isPrivate="false">little tokyo</address>
         <birthday isPrivate="false">2000/06/06</birthday>
+        <facebook isPrivate="false">9</facebook>
         <remark isPrivate="false">likes to drink alcohol</remark>
     </persons>
     <persons>
@@ -55,6 +61,7 @@
         <email isPrivate="false">anna@example.com</email>
         <address isPrivate="false">4th street</address>
         <birthday isPrivate="false">2000/07/07</birthday>
+        <facebook isPrivate="false">10</facebook>
         <remark isPrivate="false">likes talking a stroll in the park</remark>
     </persons>
     <persons>
@@ -63,6 +70,7 @@
         <email isPrivate="false">stefan@example.com</email>
         <address isPrivate="false">little india</address>
         <birthday isPrivate="false">2000/08/08</birthday>
+        <facebook isPrivate="false">11</facebook>
         <remark isPrivate="false">likes watching movies</remark>
     </persons>
     <persons>
@@ -71,6 +79,7 @@
         <email isPrivate="false">hans@example.com</email>
         <address isPrivate="false">chicago ave</address>
         <birthday isPrivate="false">2000/09/09</birthday>
+        <facebook isPrivate="false">12</facebook>
         <remark isPrivate="false">likes partying</remark>
     </persons>
 </addressbook>

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.FACEBOOK_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -12,6 +13,7 @@ import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -52,56 +54,56 @@ public class AutoCompleteTest {
     public void autoCompleteAdd_missingOneField_addMissingPrefix() {
         // missing phone
         String command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-            + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
-        String expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY
-            + " " + PREFIX_PHONE + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
+        String expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY + " " + PREFIX_PHONE + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertAutoComplete(command, expected);
 
         // missing address
-        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-            + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
-        expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY
-            + PHONE_DESC_AMY + EMAIL_DESC_AMY + " " + PREFIX_ADDRESS + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + BIRTHDAY_DESC_AMY
+                + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
+        expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + " " + PREFIX_ADDRESS
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertAutoComplete(command, expected);
     }
 
     @Test
     public void autoCompleteAdd_missingMultipleFields_addMissingPrefixes() {
         // missing name and email
-        String command = AddCommand.COMMAND_WORD + PHONE_DESC_AMY + ADDRESS_DESC_AMY
-            + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
-        String expected = AddCommand.COMMAND_WORD + " " + PREFIX_NAME + PHONE_DESC_AMY
-            + " " + PREFIX_EMAIL + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+        String command = AddCommand.COMMAND_WORD + PHONE_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY
+                + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
+        String expected = AddCommand.COMMAND_WORD + " " + PREFIX_NAME + PHONE_DESC_AMY + " " + PREFIX_EMAIL
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertAutoComplete(command, expected);
 
         // all fields are missing
         command = AddCommand.COMMAND_WORD;
         expected = AddCommand.COMMAND_WORD + " " + PREFIX_NAME + " " + PREFIX_PHONE + " " + PREFIX_EMAIL
-            + " " + PREFIX_ADDRESS + " " + PREFIX_BIRTHDAY + " " + PREFIX_TAG;
+                + " " + PREFIX_ADDRESS + " " + PREFIX_BIRTHDAY + " " + PREFIX_FACEBOOK + " " + PREFIX_TAG;
         assertAutoComplete(command, expected);
     }
 
     @Test
     public void autoCompleteAdd_invalidFields_addMissingPrefixes() {
         // invalid phone
-        String command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + " " + PREFIX_PHONE + "abc"
-            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
-        String expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY
-            + " " + PREFIX_PHONE + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+        String command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + " " + PREFIX_PHONE + "abc" + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
+        String expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY + " " + PREFIX_PHONE + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertAutoComplete(command, expected);
 
         // two name field -> choose the first one
-        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_AMY
-            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
-        expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
+        expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertAutoComplete(command, expected);
     }
 
     @Test
     public void autoCompleteAdd_allValidFields_noChange() {
-        String command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+        String command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertAutoComplete(command, command);
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -35,6 +36,8 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_BIRTHDAY_AMY = "2000/10/10";
+    public static final String VALID_FACEBOOK_BOB = "20";
+    public static final String VALID_FACEBOOK_AMY = "21";
     public static final String VALID_BIRTHDAY_BOB = "1999/10/10";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
@@ -49,6 +52,8 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String BIRTHDAY_DESC_AMY = " " + PREFIX_BIRTHDAY + VALID_BIRTHDAY_AMY;
     public static final String BIRTHDAY_DESC_BOB = " " + PREFIX_BIRTHDAY + VALID_BIRTHDAY_BOB;
+    public static final String FACEBOOK_DESC_AMY = " " + PREFIX_FACEBOOK + VALID_FACEBOOK_AMY;
+    public static final String FACEBOOK_DESC_BOB = " " + PREFIX_FACEBOOK + VALID_FACEBOOK_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -56,6 +61,7 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_BIRTHDAY_DESC = " " + PREFIX_BIRTHDAY + "a"; // 'a' is not allowed in birthday
+    public static final String INVALID_FACEBOOK_DESC = " " + PREFIX_FACEBOOK + "z"; // 'z' is not allowed in facebook
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
@@ -64,10 +70,10 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withBirthday(VALID_BIRTHDAY_AMY).withTags(VALID_TAG_FRIEND).build();
-        DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withBirthday(VALID_BIRTHDAY_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withBirthday(VALID_BIRTHDAY_AMY).withFacebook(VALID_FACEBOOK_AMY).withTags(VALID_TAG_FRIEND).build();
+        DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_BOB)
+                .withFacebook(VALID_FACEBOOK_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -49,6 +50,10 @@ public class EditPersonDescriptorTest {
 
         // different address -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withAddress(VALID_ADDRESS_BOB).build();
+        assertFalse(DESC_AMY.equals(editedAmy));
+
+        // different facebook -> returns false
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withFacebook(VALID_FACEBOOK_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different tags -> returns false

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -7,8 +7,11 @@ import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.FACEBOOK_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.FACEBOOK_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_FACEBOOK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -24,6 +27,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -32,6 +37,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -40,6 +46,7 @@ import org.junit.Test;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -53,34 +60,34 @@ public class AddCommandParserTest {
     public void parse_allFieldsPresent_success() {
         Person expectedPerson = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_BOB)
-                .withTags(VALID_TAG_FRIEND).build();
+                .withFacebook(VALID_FACEBOOK_BOB).withTags(VALID_TAG_FRIEND).build();
 
         // multiple names - last name accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB
+                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB
+                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY
-                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB
+                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_AMY + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB
+                + ADDRESS_DESC_AMY + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_BOB)
-                .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
-        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                .withFacebook(VALID_FACEBOOK_BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
+        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                    + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new AddCommand(expectedPersonMultipleTags));
     }
 
@@ -89,27 +96,39 @@ public class AddCommandParserTest {
         // zero tags
         Person expectedPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
-                .withTags().build();
-        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY, new AddCommand(expectedPerson));
+                .withFacebook(VALID_FACEBOOK_AMY).withTags().build();
+        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY, new AddCommand(expectedPerson));
 
         // no address
         Person noAddressPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress("").withBirthday(VALID_BIRTHDAY_AMY)
-            .withTags(VALID_TAG_FRIEND).build();
+                .withEmail(VALID_EMAIL_AMY).withAddress("").withBirthday(VALID_BIRTHDAY_AMY)
+                .withFacebook(VALID_FACEBOOK_AMY).withTags(VALID_TAG_FRIEND).build();
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-            + " " + PREFIX_ADDRESS + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(noAddressPerson));
-        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-            + EMAIL_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(noAddressPerson));
+                + " " + PREFIX_ADDRESS + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND,
+                new AddCommand(noAddressPerson));
+        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(noAddressPerson));
 
         // no birthday
         Person noBirthdayPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withBirthday("")
-            .withTags(VALID_TAG_FRIEND).build();
+                .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withBirthday("")
+                .withFacebook(VALID_FACEBOOK_AMY).withTags(VALID_TAG_FRIEND).build();
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-            + ADDRESS_DESC_AMY + " " + PREFIX_BIRTHDAY + TAG_DESC_FRIEND, new AddCommand(noBirthdayPerson));
-        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(noBirthdayPerson));
+                + ADDRESS_DESC_AMY + " " + PREFIX_BIRTHDAY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND,
+                new AddCommand(noBirthdayPerson));
+        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(noBirthdayPerson));
+
+        // no facebook
+        Person noFacebookPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
+                .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
+                .withFacebook("").withTags(VALID_TAG_FRIEND).build();
+        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + " " + PREFIX_FACEBOOK + TAG_DESC_FRIEND,
+                new AddCommand(noFacebookPerson));
+        assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(noFacebookPerson));
     }
 
     @Test
@@ -154,6 +173,11 @@ public class AddCommandParserTest {
         assertParseFailure(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + ADDRESS_DESC_BOB + INVALID_BIRTHDAY_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Birthday.MESSAGE_BIRTHDAY_CONSTRAINTS);
+
+        // invalid facebook
+        assertParseFailure(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + INVALID_FACEBOOK_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+            Facebook.MESSAGE_FACEBOOK_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.FACEBOOK_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
@@ -18,6 +19,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -146,6 +148,12 @@ public class EditCommandParserTest {
         // address
         userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // facebook
+        userInput = targetIndex.getOneBased() + FACEBOOK_DESC_AMY;
+        descriptor = new EditPersonDescriptorBuilder().withFacebook(VALID_FACEBOOK_AMY).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -22,6 +22,7 @@ import org.junit.rules.ExpectedException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -31,12 +32,14 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_FACEBOOK = "facebook";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
+    private static final String VALID_FACEBOOK = "4";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 
@@ -175,6 +178,31 @@ public class ParserUtilTest {
         Optional<Email> actualEmail = ParserUtil.parseEmail(Optional.of(VALID_EMAIL));
 
         assertEquals(expectedEmail, actualEmail.get());
+    }
+
+    @Test
+    public void parseFacebook_null_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
+        ParserUtil.parseFacebook(null);
+    }
+
+    @Test
+    public void parseFacebook_invalidValue_throwsIllegalValueException() throws Exception {
+        thrown.expect(IllegalValueException.class);
+        ParserUtil.parseFacebook(Optional.of(INVALID_FACEBOOK));
+    }
+
+    @Test
+    public void parseFacebook_optionalEmpty_returnsOptionalFacebook() throws Exception {
+        assertFalse(ParserUtil.parseFacebook(Optional.empty()).isPresent());
+    }
+
+    @Test
+    public void parseFacebook_validValue_returnsFacebook() throws Exception {
+        Facebook expectedFacebook = new Facebook(VALID_FACEBOOK);
+        Optional<Facebook> actualFacebook = ParserUtil.parseFacebook(Optional.of(VALID_FACEBOOK));
+
+        assertEquals(expectedFacebook, actualFacebook.get());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/DetailsContainKeyphrasePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/DetailsContainKeyphrasePredicateTest.java
@@ -13,6 +13,7 @@ public class DetailsContainKeyphrasePredicateTest {
             .withPhone("99887766")
             .withEmail("peterlim@gmail.com")
             .withAddress("Orchard Towers Block 39 #13-12")
+            .withFacebook("21")
             .withTags("business", "professional")
             .withRemark("met during a networking event")
             .build();
@@ -102,6 +103,14 @@ public class DetailsContainKeyphrasePredicateTest {
         DetailsContainKeyphrasePredicate predicateAddressDifferentCase = new DetailsContainKeyphrasePredicate("Orchard "
                 + "Towers Block 39 #13-12");
         assertTrue(predicateAddressDifferentCase.test(samplePerson));
+
+        // matches Facebook in full
+        DetailsContainKeyphrasePredicate predicateFacebookFull = new DetailsContainKeyphrasePredicate("21");
+        assertTrue(predicateAddressFull.test(samplePerson));
+
+        // matches Facebook partially
+        DetailsContainKeyphrasePredicate predicateFacebookPartially = new DetailsContainKeyphrasePredicate("1");
+        assertTrue(predicateAddressPartially.test(samplePerson));
 
         // matches Tag in full
         DetailsContainKeyphrasePredicate predicateTagFull = new DetailsContainKeyphrasePredicate("professional");

--- a/src/test/java/seedu/address/model/person/FacebookTest.java
+++ b/src/test/java/seedu/address/model/person/FacebookTest.java
@@ -1,0 +1,23 @@
+package seedu.address.model.person;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+import org.junit.Test;
+
+public class FacebookTest {
+
+    @Test
+    public void isValidFacebook() {
+        // blank facebook
+        assertFalse(Facebook.isValidFacebookId(""));
+        assertFalse(Facebook.isValidFacebookId("  "));
+
+        // not numerical facebook
+        assertFalse(Facebook.isValidFacebookId("zuck"));
+        assertFalse(Facebook.isValidFacebookId("some.user.name"));
+
+        // valid facebook
+        assertTrue(Facebook.isValidFacebookId("12345"));
+    }
+}

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -33,6 +33,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
         descriptor.setBirthday(person.getBirthday());
+        descriptor.setFacebook(person.getFacebook());
         descriptor.setTags(person.getTags());
     }
 
@@ -92,6 +93,18 @@ public class EditPersonDescriptorBuilder {
             ParserUtil.parseBirthday(Optional.of(birthday)).ifPresent(descriptor::setBirthday);
         } catch (IllegalValueException ive) {
             throw new IllegalArgumentException("birthday is expected to be unique.");
+        }
+        return this;
+    }
+
+    /**
+     * Sets the {@code Facebook} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withFacebook(String facebook) {
+        try {
+            ParserUtil.parseFacebook(Optional.of(facebook)).ifPresent(descriptor::setFacebook);
+        } catch (IllegalValueException ive) {
+            throw new IllegalArgumentException("Facebook is expected to be unique.");
         }
         return this;
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -6,6 +6,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -24,6 +25,7 @@ public class PersonBuilder {
     public static final String DEFAULT_EMAIL = "alice@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_BIRTHDAY = "2000/01/01";
+    public static final String DEFAULT_FACEBOOK = "4";
     public static final String DEFAULT_TAGS = "friends";
 
     private Person person;
@@ -35,9 +37,10 @@ public class PersonBuilder {
             Email defaultEmail = new Email(DEFAULT_EMAIL);
             Address defaultAddress = new Address(DEFAULT_ADDRESS);
             Birthday defaultBirthday = new Birthday(DEFAULT_BIRTHDAY);
+            Facebook defaultFacebook = new Facebook(DEFAULT_FACEBOOK);
             Set<Tag> defaultTags = SampleDataUtil.getTagSet(DEFAULT_TAGS);
             this.person = new Person(defaultName, defaultPhone, defaultEmail, defaultAddress, defaultBirthday,
-                    defaultTags);
+                    defaultFacebook, defaultTags);
         } catch (IllegalValueException ive) {
             throw new AssertionError("Default person's values are invalid.");
         }
@@ -118,6 +121,18 @@ public class PersonBuilder {
             this.person.setBirthday(new Birthday(birthday));
         } catch (IllegalValueException ive) {
             throw new IllegalArgumentException("birthday is expected to be unique.");
+        }
+        return this;
+    }
+
+    /**
+     * Sets the {@code Facebook} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withFacebook(String facebook) {
+        try {
+            this.person.setFacebook(new Facebook(facebook));
+        } catch (IllegalValueException ive) {
+            throw new IllegalArgumentException("Facebook is expected to be unique.");
         }
         return this;
     }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -3,6 +3,7 @@ package seedu.address.testutil;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -32,6 +33,7 @@ public class PersonUtil {
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
         sb.append(PREFIX_BIRTHDAY + person.getBirthday().value + " ");
+        sb.append(PREFIX_FACEBOOK + person.getFacebook().value + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -6,6 +6,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -28,36 +30,43 @@ public class TypicalPersons {
 
     public static final ReadOnlyPerson ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("85355255").withBirthday("2000/01/01")
+            .withPhone("85355255").withBirthday("2000/01/01").withFacebook("4")
             .withTags("friends").build();
     public static final ReadOnlyPerson BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432").withBirthday("2000/02/02")
+            .withEmail("johnd@example.com").withPhone("98765432").withBirthday("2000/02/02").withFacebook("5")
             .withTags("owesMoney", "friends").build();
     public static final ReadOnlyPerson CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").withBirthday("2000/03/03").build();
+            .withEmail("heinz@example.com").withAddress("wall street").withBirthday("2000/03/03")
+            .withFacebook("6").build();
     public static final ReadOnlyPerson DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withBirthday("2000/04/04").build();
+            .withEmail("cornelia@example.com").withAddress("10th street").withBirthday("2000/04/04")
+            .withFacebook("7").build();
     public static final ReadOnlyPerson ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").withBirthday("2000/05/05").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withBirthday("2000/05/05")
+            .withFacebook("8").build();
     public static final ReadOnlyPerson FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").withBirthday("2000/06/06").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo").withBirthday("2000/06/06")
+            .withFacebook("9").build();
     public static final ReadOnlyPerson GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").withBirthday("2000/07/07").build();
+            .withEmail("anna@example.com").withAddress("4th street").withBirthday("2000/07/07")
+            .withFacebook("10").build();
 
     // Manually added
     public static final ReadOnlyPerson HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").withBirthday("2000/08/08").build();
+            .withEmail("stefan@example.com").withAddress("little india").withBirthday("2000/08/08")
+            .withFacebook("11").build();
     public static final ReadOnlyPerson IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").withBirthday("2000/09/09").build();
+            .withEmail("hans@example.com").withAddress("chicago ave").withBirthday("2000/09/09")
+            .withFacebook("12").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final ReadOnlyPerson AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
-            .withTags(VALID_TAG_FRIEND).build();
+            .withFacebook(VALID_FACEBOOK_AMY).withTags(VALID_TAG_FRIEND).build();
     public static final ReadOnlyPerson BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_BOB)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+            .withFacebook(VALID_FACEBOOK_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -8,8 +8,11 @@ import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.FACEBOOK_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.FACEBOOK_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_FACEBOOK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -24,6 +27,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -50,6 +55,7 @@ import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.Model;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
@@ -69,7 +75,8 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
          */
         ReadOnlyPerson toAdd = AMY;
         String command = "   " + AddCommand.COMMAND_WORD + "  " + NAME_DESC_AMY + "  " + PHONE_DESC_AMY + " "
-                + EMAIL_DESC_AMY + "   " + ADDRESS_DESC_AMY + "   " + BIRTHDAY_DESC_AMY + "   " + TAG_DESC_FRIEND + " ";
+                + EMAIL_DESC_AMY + "   " + ADDRESS_DESC_AMY + "   " + BIRTHDAY_DESC_AMY + "   " + FACEBOOK_DESC_AMY
+                + "   " + TAG_DESC_FRIEND + " ";
         assertCommandSuccess(command, toAdd);
 
         /* Case: undo adding Amy to the list -> Amy deleted */
@@ -85,7 +92,7 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: add a duplicate person -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_PERSON);
 
         /* Case: add a duplicate person except with different tags -> rejected */
@@ -93,35 +100,47 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         // This test will fail is a new tag that is not in the model is used, see the bug documented in
         // AddressBook#addPerson(ReadOnlyPerson)
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + " " + PREFIX_TAG.getPrefix() + "friends";
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + " " + PREFIX_TAG.getPrefix() + "friends";
         assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_PERSON);
 
         /* Case: add a person with all fields same as another person in the address book except name -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
-                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withFacebook(VALID_FACEBOOK_AMY)
+                .withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a person with all fields same as another person in the address book except phone -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY)
-                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withFacebook(VALID_FACEBOOK_AMY)
+                .withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a person with all fields same as another person in the address book except email -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withFacebook(VALID_FACEBOOK_AMY)
+                .withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a person with all fields same as another person in the address book except address -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
-                .withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_AMY).withFacebook(VALID_FACEBOOK_AMY)
+                .withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_BOB
-                + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
+        assertCommandSuccess(command, toAdd);
+
+        /* Case: add a person with all fields same as another person in the address book except facebook -> added */
+        toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
+            .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withFacebook(VALID_FACEBOOK_BOB)
+            .withTags(VALID_TAG_FRIEND).build();
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+            + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_BOB + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: filters the person list before adding -> added */
@@ -137,8 +156,8 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: add a person with tags, command with parameters in random order -> added */
         toAdd = BOB;
-        command = AddCommand.COMMAND_WORD + TAG_DESC_FRIEND + BIRTHDAY_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
-                + NAME_DESC_BOB + TAG_DESC_HUSBAND + EMAIL_DESC_BOB;
+        command = AddCommand.COMMAND_WORD + TAG_DESC_FRIEND + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB + PHONE_DESC_BOB
+                + ADDRESS_DESC_BOB + NAME_DESC_BOB + TAG_DESC_HUSBAND + EMAIL_DESC_BOB;
         assertCommandSuccess(command, toAdd);
 
         /* Case: selects first card in the person list, add a person -> added, card selection remains unchanged */
@@ -150,15 +169,18 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         assertCommandSuccess(HOON);
 
         /* Case: missing name -> rejected */
-        command = AddCommand.COMMAND_WORD + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY;
+        command = AddCommand.COMMAND_WORD + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY;
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         /* Case: missing phone -> rejected */
-        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY;
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY;
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         /* Case: missing email -> rejected */
-        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY;
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY;
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         /* Case: invalid keyword -> rejected */
@@ -167,27 +189,32 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: invalid name -> rejected */
         command = AddCommand.COMMAND_WORD + INVALID_NAME_DESC + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY;
         assertCommandFailure(command, Name.MESSAGE_NAME_CONSTRAINTS);
 
         /* Case: invalid phone -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + INVALID_PHONE_DESC + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY;
         assertCommandFailure(command, Phone.MESSAGE_PHONE_CONSTRAINTS);
 
         /* Case: invalid email -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + INVALID_EMAIL_DESC + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY;
+                + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY;
         assertCommandFailure(command, Email.MESSAGE_EMAIL_CONSTRAINTS);
 
         /* Case: invalid birthday -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + INVALID_BIRTHDAY_DESC;
+                + INVALID_BIRTHDAY_DESC + FACEBOOK_DESC_AMY;
         assertCommandFailure(command, Birthday.MESSAGE_BIRTHDAY_CONSTRAINTS);
+
+        /* Case: invalid facebook -> rejected */
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+            + VALID_ADDRESS_AMY + INVALID_FACEBOOK_DESC;
+        assertCommandFailure(command, Facebook.MESSAGE_FACEBOOK_CONSTRAINTS);
 
         /* Case: invalid tag -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + INVALID_TAG_DESC;
+                + BIRTHDAY_DESC_AMY  + FACEBOOK_DESC_AMY + INVALID_TAG_DESC;
         assertCommandFailure(command, Tag.MESSAGE_TAG_CONSTRAINTS);
     }
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -9,7 +9,10 @@ import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.FACEBOOK_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.FACEBOOK_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_FACEBOOK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -21,6 +24,7 @@ import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FACEBOOK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
@@ -41,6 +45,7 @@ import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.Model;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Facebook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -64,10 +69,12 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
          * -> edited
          */
         Index index = INDEX_FIRST_PERSON;
-        String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + NAME_DESC_BOB + "  "
-                + PHONE_DESC_BOB + " " + EMAIL_DESC_BOB + "  " + ADDRESS_DESC_BOB + " " + TAG_DESC_HUSBAND + " ";
+        String command = "   " + EditCommand.COMMAND_WORD + "   " + index.getOneBased() + "  " + NAME_DESC_BOB
+                + "     " + PHONE_DESC_BOB + "    " + EMAIL_DESC_BOB + "    " + ADDRESS_DESC_BOB + "     "
+                + FACEBOOK_DESC_BOB + " " + TAG_DESC_HUSBAND + "   ";
         Person editedPerson = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withFacebook(VALID_FACEBOOK_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
         assertCommandSuccess(command, index, editedPerson);
 
         /* Case: undo editing the last person in the list -> last person restored */
@@ -84,7 +91,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: edit a person with new values same as existing values -> edited */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
+                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
         assertCommandSuccess(command, index, BOB);
 
         /* Case: edit some fields -> edited */
@@ -128,7 +135,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         index = INDEX_FIRST_PERSON;
         selectPerson(index);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + FACEBOOK_DESC_AMY + TAG_DESC_FRIEND;
         // this can be misleading: card selection actually remains unchanged but the
         // browser's url is updated to reflect the new person's name
         assertCommandSuccess(command, index, AMY, index);
@@ -168,6 +175,10 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + INVALID_EMAIL_DESC,
                 Email.MESSAGE_EMAIL_CONSTRAINTS);
 
+        /* Case: invalid email -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + INVALID_FACEBOOK_DESC,
+            Facebook.MESSAGE_FACEBOOK_CONSTRAINTS);
+
         /* Case: invalid tag -> rejected */
         assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + INVALID_TAG_DESC,
                 Tag.MESSAGE_TAG_CONSTRAINTS);
@@ -178,12 +189,12 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         index = INDEX_FIRST_PERSON;
         assertFalse(getModel().getFilteredPersonList().get(index.getZeroBased()).equals(BOB));
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
+                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
 
         /* Case: edit a person with new values same as another person's values but with different tags -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TAG_DESC_HUSBAND;
+                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + FACEBOOK_DESC_BOB + TAG_DESC_HUSBAND;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 

--- a/src/test/java/systemtests/ImportCommandSystemTest.java
+++ b/src/test/java/systemtests/ImportCommandSystemTest.java
@@ -62,12 +62,12 @@ public class ImportCommandSystemTest extends AddressBookSystemTest {
          * -> imported with duplicated persons ignored
          */
         ReadOnlyPerson james = new PersonBuilder().withName("James Turner").withPhone("66666666")
-            .withEmail("james@example.com").withAddress("Sydney").withBirthday("2000/01/01")
-                .withTags("friends").build();
+                .withEmail("james@example.com").withAddress("Sydney").withBirthday("2000/01/01")
+                .withFacebook("30").withTags("friends").build();
         expectedModel.addPerson(james);
         command = getCommandWord("DuplicatedPersonInAddressBook.xml");
         expectedMessage = ImportCommand.MESSAGE_DUPLICATED_PERSON_IN_ADDRESS_BOOK_WARNING
-            + String.format(ImportCommand.MESSAGE_IMPORT_SUCCESS, 2);
+                + String.format(ImportCommand.MESSAGE_IMPORT_SUCCESS, 2);
         assertCommandSuccess(command, expectedModel, expectedMessage);
 
         /* Case: import to an empty address book -> imported */


### PR DESCRIPTION
Add Facebook field to contact. Facebook field represents Facebook ID (a long number), rather than Facebook user name, due to the difficulty to convert them.